### PR TITLE
Add placeholders for .env files for client & server

### DIFF
--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -1,0 +1,5 @@
+export const environment = {
+    production: true,
+    serverUrl: '', // Your AWS EC2 instance URL pointing to /api (ex: 'http://ec2-xx-xxx-xxx-xxx.us-east-2.compute.amazonaws.com:3000/api')
+    socketUrl: '', // Your AWS EC2 instance URL pointing to / (ex: 'http://ec2-xx-xxx-xxx-xxx.us-east-2.compute.amazonaws.com:3000')
+};

--- a/server/app/env.ts
+++ b/server/app/env.ts
@@ -1,0 +1,3 @@
+export const env = {
+    dbUrl: '', // Your MongoDB Atlas URL pointing to the database (ex: 'mongodb+srv://<username>:<password>@<cluster>/<database>?retryWrites=true&w=majority')
+};


### PR DESCRIPTION
After removing the .env files that were accidentally pushed, this PR adds them back, but without the private API keys. Instead, they contain example (harmless) keys to guide users who want to use their own API keys.